### PR TITLE
Add --force option to publisssh on deploy-to-production

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "gulp",
     "deploy-to-staging": "gulp clean && gulp build && publisssh ./public/build demo.zooniverse.org/chimps-staging && gulp clean",
     "deploy-to-beta": "gulp clean && gulp build && publisssh ./public/build zooniverse-static/www.chimpandsee.org/beta && gulp clean",
-    "deploy-to-production": "gulp clean && gulp build && publisssh ./public/build zooniverse-static/www.chimpandsee.org && gulp clean",
+    "deploy-to-production": "gulp clean && gulp build && publisssh ./public/build zooniverse-static/www.chimpandsee.org --force && gulp clean",
     "deploy": "npm run deploy-to-staging && npm run deploy-to-production"
   },
   "devDependencies": {


### PR DESCRIPTION
Issue: Having updated publisssh to 1.1.0 (see #128), it became impossible to run `npm run deploy-to-production` as the progress would 'freeze' at...
```
Local: ./public/build
Bucket: zooniverse-static
Prefix: www.chimpandsee.org 
```
(i.e. no response even after 20 minutes)

Analysis:
As @eatyourgreens helpfully pointed out,
> publisssh is attempting to list every image in the subjects/ directory. Two possible solutions:
> a) roll back to the old versions of publisssh and node.
> b) add the --force option to workaround by ignoring file synching, like here https://github.com/zooniverse/operationwardiary/blob/master/package.json#L21-L22
```
21.  "deploy": "haw build && publisssh ./build zooniverse-static/www.operationwardiary.org --force && rm -rf ./build",
22.  "deploy-beta": "haw build && publisssh ./build zooniverse-static/www.operationwardiary.org/beta --force && rm -rf ./build"
```

Solution:
Added a `--force` option to publissh on `deploy-to-production`
