### PR TITLE
Fix previews to use https

### DIFF
--- a/app/classify.cjsx
+++ b/app/classify.cjsx
@@ -90,11 +90,16 @@ module?.exports = React.createClass
     @removeClassesForGuide()
 
   onSubjectSelect: (e, subject) ->
-    previews = subject.location.previews
     randomInt = if subject.location.previews.length is 2 then Math.round(Math.random()) else Math.round(Math.random() * (2 - 0)) + 0
+    previews = subject.location.previews[randomInt]
+
+    if window.location.hostname is "www.chimpandsee.org"
+      previews = previews.map (preview, i) ->
+        preview = preview.replace("http", "https")
+
     @setState({
       video: subject.location.standard
-      previews: previews[randomInt]
+      previews: previews
       location: subject.group.name
       classification: new Classification {subject}
     }, => @onSubjectUpdate(randomInt))


### PR DESCRIPTION
Replaces the previews locations to use https if in production. I found that this didn't work using the staging data from demo.zooniverse.org maybe because https isn't setup for that subdomain? I deployed to the beta bucket so it can be checked out: https://www.chimpandsee.org/beta/#/classify