### PR TITLE
Update navigation.cjsx

### DIFF
--- a/app/navigation.cjsx
+++ b/app/navigation.cjsx
@@ -52,7 +52,6 @@ module?.exports = React.createClass
         <a href="http://talk.chimpandsee.org/" target="chimptalk">Discuss</a>
         <a href="http://chimpandsee.blogspot.de/" target="chimpblog">Blog</a>
         <a href="https://talk.chimpandsee.org/#/boards/BCP0000007/discussions/DCP0000qvb" target="_blank">FAQ</a>
-        <a href="https://talk.chimpandsee.org/#/boards/BCP000000c/discussions/DCP0001izd" target="_blank">Best of 2016</a>
       </div>
       <img className="chimpster" src="./assets/chimpster.png" alt="" />
     </nav>


### PR DESCRIPTION
Removed link to Best of 2016 event.

Note:  I know that there were some CSS styling changes made to allow for this link to be added to the top nav of classification.  I don't know whether that needs to be undone, or if those changes can be left in place to accommodate an additional link in the future.